### PR TITLE
Downgrade target framework

### DIFF
--- a/src/Fable.ReactTransitionGroup.fsproj
+++ b/src/Fable.ReactTransitionGroup.fsproj
@@ -11,7 +11,7 @@ Fable bindings for react-transition-group npm package
     <Authors>Tobias Burger</Authors>
     <Version>1.0.0-beta-002</Version>
     <PackageVersion>1.0.0-beta-002</PackageVersion>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Don't think this needs to be set to 2.1. Can't use the Nuget package because my Fable project is at 2.0 (and most other people's too I assume).