### PR TITLE
Change the type of TransitionGroupProp.Component

### DIFF
--- a/src/Fable.ReactTransitionGroup.fs
+++ b/src/Fable.ReactTransitionGroup.fs
@@ -139,7 +139,7 @@ type TransitionGroupProp =
     /// You can change this behavior by providing a component prop.
     /// If you use React v16+ and would like to avoid a wrapping <div> element you can pass in `Component null`.
     /// This is useful if the wrapping div borks your css styles.
-    | Component of ReactElement
+    | Component of string
     /// A convenience prop that enables or disables appear animations for all children.
     /// Note that specifying this will override any defaults set on individual children Transitions.
     | Appear of bool


### PR DESCRIPTION
Currently you are allowed to do `transitionGroup [ TransitionGroupProp.Component (div [] []) ]`, which crashes the application.
The [docs](http://reactcommunity.org/react-transition-group/transition-group#TransitionGroup-prop-component) list the type as `any`, but I think only `string` should realistically be accepted (unless you know of a clever way of making it type/element safe), since this produces the expected result `transitionGroup [ TransitionGroupProp.Component (nameof span |> unbox) ]`.